### PR TITLE
fix: change foundation dropdown to link

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -37,7 +37,6 @@ const InfoDisclaimer = () => (
 const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
   const [isLangMenuShown, setIsLangMenuShown] = useState(false)
   const [isConferencesMenuShown, setIsConferencesMenuShown] = useState(false)
-  const [isAboutMenuShown, setIsAboutMenuShown] = useState(false)
 
   const setLang = useCallback(lang => {
     setLanguage(lang)
@@ -87,15 +86,7 @@ const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
         </span>
       </span>
       <a href="/slack">Slack</a>
-      <span className="languageSelect about">
-        <button className="button" onClick={() => setIsAboutMenuShown(!isAboutMenuShown)} type="button">Foundation <span className="triangle">▾</span></button>
-        <span className={`list${isAboutMenuShown ? ' is-shown' : ''}`}>
-          <Link className="link" to="/foundation">Governance</Link>
-          <Link className="link" to="/charter">Charter</Link>
-          <Link className="link" to="https://github.com/ebpf-io/bsc/blob/master/minutes.md">BSC Meeting Minutes</Link>
-          <Link className="link" to="/contribute">How to Contribute</Link>
-        </span>
-      </span>
+      <a href="/foundation">Foundation</a>
       {hasLanguage && <span className="languageSelect">
         <button className="button" onClick={() => setIsLangMenuShown(!isLangMenuShown)} type="button">{getLanguageName(language)} <span className="triangle">▾</span></button>
         <span className={`list${isLangMenuShown ? ' is-shown' : ''}`}>
@@ -111,7 +102,6 @@ const HeaderMobile = ({ language, hasLanguage, setLanguage }) => {
   const toggleIsOpen = useCallback(() => setIsOpen(!isOpen), [isOpen, setIsOpen]);
   const [isLangMenuShown, setIsLangMenuShown] = useState(false);
   const [isConferencesMenuShown, setIsConferencesMenuShown] = useState(false);
-  const [isAboutMenuShown, setIsAboutMenuShown] = useState(false);
 
   const setLang = useCallback(lang => {
     setLanguage(lang)
@@ -165,15 +155,7 @@ const HeaderMobile = ({ language, hasLanguage, setLanguage }) => {
             </span>
           </span>
           <a href="/slack">Slack</a>
-          <span className="languageSelect about">
-            <button className="button" onClick={() => setIsAboutMenuShown(!isAboutMenuShown)} type="button">Foundation <span className="triangle">▾</span></button>
-            <span className={`list${isAboutMenuShown ? ' is-shown' : ''}`}>
-              <Link className="link" to="/foundation">Governance</Link>
-              <Link className="link" to="/charter">Charter</Link>
-              <Link className="link" to="https://github.com/ebpf-io/bsc/blob/master/minutes.md">BSC Meeting Minutes</Link>
-              <Link className="link" to="/contribute">How to Contribute</Link>
-            </span>
-          </span>
+          <a href="/foundation">Foundation</a>
           {hasLanguage && <span className="languageSelect">
             <button className="button" onClick={() => setIsLangMenuShown(!isLangMenuShown)} type="button">{getLanguageName(language)} <span className="triangle">▾</span></button>
             <span className={`list${isLangMenuShown ? ' is-shown' : ''}`}>


### PR DESCRIPTION
This pull request changes the menu dropdown Foundation to a link `/foundation`.

**Screenshots**
<img width="1121" alt="image" src="https://user-images.githubusercontent.com/48465000/172640796-46329da6-5795-4b7c-b457-c5861d77179f.png">
