### PR TITLE
index: Enlarge the main buttons on the welcome page

### DIFF
--- a/src/stylesheets/index.scss
+++ b/src/stylesheets/index.scss
@@ -176,7 +176,7 @@ code {
     }
 
     &.main-button {
-      width: 300px;
+      width: 350px;
       text-align: center;
       margin-right: 16px;
       color: #000;


### PR DESCRIPTION
The two main buttons (“Whats is eBPF?” and “Project Landscape”) on the index page had a fixed width of 300px. Since the text on the one on the right has been changed to “Project Landscape”, the width is not enough to accommodate for the text length and the padding for the button on my browser, making the text content not centred.

This commit raises the width to 350px instead.

Before:

![image](https://user-images.githubusercontent.com/17001771/173683323-924f5c48-f86d-4b7c-928e-0413c7b5e8c8.png)

After:

![image](https://user-images.githubusercontent.com/17001771/173683268-33341718-ba40-486f-80bd-82a92e440908.png)
